### PR TITLE
Removes Visibility Modifiers from New Methods

### DIFF
--- a/lib/chargify_api_ares/resources/subscription.rb
+++ b/lib/chargify_api_ares/resources/subscription.rb
@@ -221,8 +221,6 @@ module Chargify
         profile
       end
 
-      private
-
       def change_payment_profile
         @persisted = true
         # Perform the request. This corresponds to 

--- a/lib/chargify_api_ares/resources/subscription.rb
+++ b/lib/chargify_api_ares/resources/subscription.rb
@@ -208,7 +208,7 @@ module Chargify
       # Update the default payment profile for the subscription identified by
       # `subscription_id` to the payment profile identified by `id`
       def self.change_payment_profile(id, subscription_id:)
-        profile = self.new(id: id, prefix_options: { subscription_id: subscription_id })
+        profile = new(id: id, prefix_options: { subscription_id: subscription_id })
         profile.change_payment_profile
         profile
       end
@@ -216,7 +216,7 @@ module Chargify
       # Delete this payment method from the given subscription AND ALL OTHER SUBSCRIPTIONS.
       # This is used to _actually_ remove a payment profile completely.
       def self.delete(id, subscription_id:)
-        profile = self.new(id: id, prefix_options: { subscription_id: subscription_id })
+        profile = new(id: id, prefix_options: { subscription_id: subscription_id })
         profile.delete_self
         profile
       end


### PR DESCRIPTION
Once I tried using these updates in the `patron-portal`, it quickly brought this error to light.

Calling the `change_payment_profile` method raised an error since it was a `private` method. Even as a `protected` method, the class method was still unable to call it successfully.

This resolves the errors.